### PR TITLE
- removed interval check

### DIFF
--- a/lib/utils/src/compass.dart
+++ b/lib/utils/src/compass.dart
@@ -50,14 +50,7 @@ class _Compass {
         _internalUpdateController.stream.listen((value) {
       if (interval != null) {
         DateTime instant = DateTime.now();
-        int difference = instant
-            .difference(compassStreamSubscription!.lastUpdated!)
-            .inMicroseconds;
-        if (difference < interval.inMicroseconds) {
-          return;
-        } else {
-          compassStreamSubscription.lastUpdated = instant;
-        }
+        compassStreamSubscription?.lastUpdated = instant;
       }
 
       compassStreamController!.add(getCompassValues(value.angle,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
 
   vector_math: ^2.1.4
   location: ^5.0.3
-  sensors_plus: ^5.0.1
+  sensors_plus: any
   logger: ^1.0.0
 platforms:
   android:


### PR DESCRIPTION
The interval check prevented showing the compass on iOS if the smartphone was not moved. I could not see any problems removing this piece of code. Neither on iOS nor on Android.